### PR TITLE
Add Health Auto Export JSON support (metrics + workouts) and VO2 max

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "apple-health-mcp",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^4.3.6"
@@ -18,6 +19,9 @@
         "@types/node": "^22.13.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -10,7 +10,9 @@ import { VERSION } from "./version.js";
 const BASE = process.env.APPLE_HEALTH_EXPORT_DIR ??
   join(homedir(), "Library/Mobile Documents/iCloud~com~ifunography~HealthExport/Documents");
 const METRICS_DIR = join(BASE, "Daily Export");
+const METRICS_DIR_JSON = join(BASE, "Health metrics");
 const WORKOUTS_DIR = join(BASE, "Workouts");
+const WORKOUTS_DIR_JSON = join(BASE, "Workout metrics");
 
 const server = new McpServer({ name: "apple-health", version: VERSION });
 
@@ -57,6 +59,7 @@ interface DailyMetrics {
   sleep_core: number;
   sleep_awake: number;
   sleep_inbed: number;
+  vo2_max: number[];
 }
 
 function parseCSV(content: string): Array<Record<string, string>> {
@@ -87,11 +90,8 @@ const SLEEP_FIELDS: Array<[string, keyof DailyMetrics]> = [
   ["Sleep Analysis [Awake] (hr)", "sleep_awake"],
 ];
 
-function parseMetrics(date: string): DailyMetrics | null {
-  const path = join(METRICS_DIR, `HealthMetrics-${date}.csv`);
-  if (!existsSync(path)) return null;
-
-  const totals: DailyMetrics = {
+function emptyTotals(): DailyMetrics {
+  return {
     active_energy: 0, steps: 0, distance: 0, flights: 0,
     resting_hr: [], hrv: [], resp_rate: [], blood_o2: [],
     hr_min: [], hr_max: [], wrist_temp: [],
@@ -99,34 +99,123 @@ function parseMetrics(date: string): DailyMetrics | null {
     weight: [], body_fat: [], lean_mass: [],
     sleep_total: 0, sleep_asleep: 0, sleep_deep: 0,
     sleep_rem: 0, sleep_core: 0, sleep_awake: 0, sleep_inbed: 0,
+    vo2_max: [],
   };
+}
 
+const SUM_METRIC_TO_FIELD: Record<string, keyof DailyMetrics> = {
+  active_energy: "active_energy",
+  step_count: "steps",
+  walking_running_distance: "distance",
+  flights_climbed: "flights",
+  apple_exercise_time: "exercise_min",
+  apple_stand_hour: "stand_hr",
+};
+
+const LIST_METRIC_TO_FIELD: Record<string, keyof DailyMetrics> = {
+  resting_heart_rate: "resting_hr",
+  heart_rate_variability: "hrv",
+  respiratory_rate: "resp_rate",
+  blood_oxygen_saturation: "blood_o2",
+  apple_sleeping_wrist_temperature: "wrist_temp",
+  weight_body_mass: "weight",
+  body_fat_percentage: "body_fat",
+  lean_body_mass: "lean_mass",
+  vo2_max: "vo2_max",
+};
+
+const SLEEP_JSON_FIELDS: Array<[string, keyof DailyMetrics]> = [
+  ["totalSleep", "sleep_total"],
+  ["asleep", "sleep_asleep"],
+  ["inBed", "sleep_inbed"],
+  ["deep", "sleep_deep"],
+  ["rem", "sleep_rem"],
+  ["core", "sleep_core"],
+  ["awake", "sleep_awake"],
+];
+
+function parseMetricsJson(date: string): DailyMetrics | null {
+  const path = join(METRICS_DIR_JSON, `HealthAutoExport-${date}.json`);
+  if (!existsSync(path)) return null;
+
+  const raw = JSON.parse(readFileSync(path, "utf-8"));
+  const metrics: Array<{ name: string; data?: Array<Record<string, unknown>> }> = raw?.data?.metrics ?? [];
+  const totals = emptyTotals();
+
+  for (const m of metrics) {
+    const samples = m.data ?? [];
+    const sumField = SUM_METRIC_TO_FIELD[m.name];
+    if (sumField) {
+      for (const s of samples) {
+        const q = s.qty;
+        if (typeof q === "number") (totals[sumField] as number) += q;
+      }
+      continue;
+    }
+    const listField = LIST_METRIC_TO_FIELD[m.name];
+    if (listField) {
+      for (const s of samples) {
+        const q = s.qty;
+        if (typeof q === "number") (totals[listField] as number[]).push(q);
+      }
+      continue;
+    }
+    if (m.name === "heart_rate") {
+      for (const s of samples) {
+        if (typeof s.Min === "number") totals.hr_min.push(s.Min as number);
+        if (typeof s.Max === "number") totals.hr_max.push(s.Max as number);
+      }
+      continue;
+    }
+    if (m.name === "sleep_analysis") {
+      for (const s of samples) {
+        for (const [jsonField, totalKey] of SLEEP_JSON_FIELDS) {
+          const v = s[jsonField];
+          if (typeof v === "number" && v > (totals[totalKey] as number)) {
+            (totals[totalKey] as number) = v;
+          }
+        }
+      }
+    }
+  }
+
+  return totals;
+}
+
+function parseMetricsCsvFile(path: string): DailyMetrics | null {
+  if (!existsSync(path)) return null;
+
+  const totals = emptyTotals();
   const rows = parseCSV(readFileSync(path, "utf-8"));
 
   for (const row of rows) {
-    const val = (key: string): number | null => {
-      const v = row[key];
-      if (!v || v === "") return null;
-      const n = parseFloat(v);
-      return isNaN(n) ? null : n;
+    const val = (...keys: string[]): number | null => {
+      for (const k of keys) {
+        const v = row[k];
+        if (!v || v === "") continue;
+        const n = parseFloat(v);
+        if (!isNaN(n)) return n;
+      }
+      return null;
     };
 
     const ae = val("Active Energy (kcal)"); if (ae) totals.active_energy += ae;
-    const sc = val("Step Count (steps)"); if (sc) totals.steps += sc;
+    const sc = val("Step Count (count)", "Step Count (steps)"); if (sc) totals.steps += sc;
     const dist = val("Walking + Running Distance (mi)"); if (dist) totals.distance += dist;
     const fl = val("Flights Climbed (count)"); if (fl) totals.flights += fl;
-    const rhr = val("Resting Heart Rate (bpm)"); if (rhr) totals.resting_hr.push(rhr);
+    const rhr = val("Resting Heart Rate (count/min)", "Resting Heart Rate (bpm)"); if (rhr) totals.resting_hr.push(rhr);
     const hrv = val("Heart Rate Variability (ms)"); if (hrv) totals.hrv.push(hrv);
     const rr = val("Respiratory Rate (count/min)"); if (rr) totals.resp_rate.push(rr);
     const o2 = val("Blood Oxygen Saturation (%)"); if (o2) totals.blood_o2.push(o2);
-    const hrMin = val("Heart Rate [Min] (bpm)"); if (hrMin) totals.hr_min.push(hrMin);
-    const hrMax = val("Heart Rate [Max] (bpm)"); if (hrMax) totals.hr_max.push(hrMax);
-    const wt = val("Apple Sleeping Wrist Temperature (ºF)"); if (wt) totals.wrist_temp.push(wt);
+    const hrMin = val("Heart Rate [Min] (count/min)", "Heart Rate [Min] (bpm)"); if (hrMin) totals.hr_min.push(hrMin);
+    const hrMax = val("Heart Rate [Max] (count/min)", "Heart Rate [Max] (bpm)"); if (hrMax) totals.hr_max.push(hrMax);
+    const wt = val("Apple Sleeping Wrist Temperature (degF)", "Apple Sleeping Wrist Temperature (ºF)"); if (wt) totals.wrist_temp.push(wt);
     const ex = val("Apple Exercise Time (min)"); if (ex) totals.exercise_min += ex;
-    const sh = val("Apple Stand Hour (hr)"); if (sh) totals.stand_hr += sh;
-    const w = val("Weight (lbs)"); if (w) totals.weight.push(w);
+    const sh = val("Apple Stand Hour (count)", "Apple Stand Hour (hr)"); if (sh) totals.stand_hr += sh;
+    const w = val("Weight (lb)", "Weight (lbs)"); if (w) totals.weight.push(w);
     const bf = val("Body Fat Percentage (%)"); if (bf) totals.body_fat.push(bf);
-    const lm = val("Lean Body Mass (lbs)"); if (lm) totals.lean_mass.push(lm);
+    const lm = val("Lean Body Mass (lb)", "Lean Body Mass (lbs)"); if (lm) totals.lean_mass.push(lm);
+    const v = val("VO2 Max (ml/(kg·min))", "VO2 Max (ml/(kg·min))"); if (v) totals.vo2_max.push(v);
 
     for (const [csvKey, totalKey] of SLEEP_FIELDS) {
       const v = val(csvKey);
@@ -137,6 +226,12 @@ function parseMetrics(date: string): DailyMetrics | null {
   }
 
   return totals;
+}
+
+function parseMetrics(date: string): DailyMetrics | null {
+  return parseMetricsJson(date)
+    ?? parseMetricsCsvFile(join(METRICS_DIR_JSON, `HealthMetrics-${date}.csv`))
+    ?? parseMetricsCsvFile(join(METRICS_DIR, `HealthMetrics-${date}.csv`));
 }
 
 interface Workout {
@@ -159,7 +254,59 @@ interface Workout {
   elevation_descended: string | null;
 }
 
+function fmtSeconds(s: number): string {
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = Math.round(s % 60);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(h)}:${pad(m)}:${pad(sec)}`;
+}
+
+function trimDate(s: unknown): string {
+  // "2026-05-25 11:36:53 -0600" -> "2026-05-25 11:36"
+  if (typeof s !== "string") return "";
+  return s.slice(0, 16);
+}
+
+function parseWorkoutsJson(date: string): Workout[] | null {
+  const path = join(WORKOUTS_DIR_JSON, `HealthAutoExport-${date}.json`);
+  if (!existsSync(path)) return null;
+
+  const raw = JSON.parse(readFileSync(path, "utf-8"));
+  const workouts: Array<Record<string, unknown>> = raw?.data?.workouts ?? [];
+  const qty = (v: unknown): string | null => {
+    if (typeof v === "object" && v !== null && "qty" in v) {
+      const q = (v as { qty: unknown }).qty;
+      if (typeof q === "number") return String(+q.toFixed(2));
+    }
+    return null;
+  };
+
+  return workouts.map(w => ({
+    type: typeof w.name === "string" ? w.name : "",
+    start: trimDate(w.start),
+    end: trimDate(w.end),
+    duration: typeof w.duration === "number" ? fmtSeconds(w.duration) : "",
+    active_cal: qty(w.activeEnergyBurned) ?? qty(w.activeEnergy),
+    total_cal: null,
+    avg_hr: qty(w.avgHeartRate),
+    max_hr: qty(w.maxHeartRate),
+    distance: qty(w.distance) ?? qty(w.walkingAndRunningDistance),
+    avg_speed: qty(w.speed),
+    steps: qty(w.stepCount),
+    step_cadence: qty(w.stepCadence),
+    swim_strokes: qty(w.swimmingStrokeCount),
+    swim_cadence: qty(w.swimStrokeCadence),
+    flights: qty(w.flightsClimbed),
+    elevation_ascended: qty(w.elevationAscended),
+    elevation_descended: qty(w.elevationDescended),
+  }));
+}
+
 function parseWorkouts(date: string): Workout[] {
+  const fromJson = parseWorkoutsJson(date);
+  if (fromJson !== null) return fromJson;
+
   const path = join(WORKOUTS_DIR, `Workouts-${date}.csv`);
   if (!existsSync(path)) return [];
 
@@ -193,6 +340,7 @@ function formatDailySummary(date: string, metrics: DailyMetrics, workouts: Worko
       weight: avg(metrics.weight),
       body_fat_pct: avg(metrics.body_fat),
       lean_mass: avg(metrics.lean_mass),
+      vo2_max: avg(metrics.vo2_max),
     },
     activity: {
       steps: Math.round(metrics.steps),
@@ -240,7 +388,7 @@ server.registerTool("apple_health_daily", {
 }, async ({ date }) => {
   const d = date ?? today();
   const metrics = parseMetrics(d);
-  if (!metrics) return text({ error: `No health data found for ${d}`, path: METRICS_DIR });
+  if (!metrics) return text({ error: `No health data found for ${d}`, paths: [METRICS_DIR_JSON, METRICS_DIR] });
   const workouts = parseWorkouts(d);
   return text(formatDailySummary(d, metrics, workouts));
 });
@@ -273,14 +421,21 @@ server.registerTool("apple_health_trends", {
     if (metrics) {
       const rhr = avg(metrics.resting_hr);
       const hrv = avg(metrics.hrv);
+      const v = avg(metrics.vo2_max);
+      const restorative = metrics.sleep_total > 0
+        ? Math.round(((metrics.sleep_deep + metrics.sleep_rem) / metrics.sleep_total) * 100)
+        : null;
       results.push({
         date: d,
         steps: Math.round(metrics.steps),
         active_energy: Math.round(metrics.active_energy),
+        exercise_min: Math.round(metrics.exercise_min),
         resting_hr: rhr ? Math.round(rhr) : null,
         hrv: hrv ? Math.round(hrv) : null,
         sleep_total_hrs: +metrics.sleep_total.toFixed(1),
+        sleep_restorative_pct: restorative,
         weight: avg(metrics.weight),
+        vo2_max: v ? +v.toFixed(1) : null,
       });
     }
   }


### PR DESCRIPTION
## Problem

The Health Auto Export (HAE) iOS app exports JSON into two separate top-level folders — `Health metrics/` and `Workout metrics/` — distinct from the legacy CSV layout (`Daily Export/` and `Workouts/`) the parser assumed. Because the paths were hardcoded to the CSV folders, recent metrics and workouts written as JSON never reached the MCP. In my case a Watch-logged outdoor run was missing entirely until I traced it to the unparsed `Workout metrics/` folder.

## Changes

- **`parseMetricsJson` / `parseWorkoutsJson`** — read HAE's JSON export schema (`data.metrics[]` and `data.workouts[]`).
- **Three-layer metrics fallback** per date: `Health metrics/HealthAutoExport-DATE.json` → `Health metrics/HealthMetrics-DATE.csv` → legacy `Daily Export/HealthMetrics-DATE.csv`. Workouts fall back JSON → legacy `Workouts/Workouts-DATE.csv`.
- **VO2 max** added to `DailyMetrics`, surfaced in `body.vo2_max` and per-day in trends.
- **Trends extended** with `exercise_min` and `sleep_restorative_pct` ((deep + REM) / total).
- **CSV column-name tolerance** — accepts newer HAE unit variants (`count/min`, `lb`, `degF`, `count`) alongside the original names, so the legacy CSV path keeps working across HAE versions.

All changes are additive and fall back to the existing CSV behavior when JSON isn't present, so current CSV-only setups are unaffected.

## Testing

Verified live against my own export: a 5/25 Outdoor Run (24:05, 2.78 mi, avg HR 162 / max 182) and two 5/26 walks now flow through `apple_health_workouts` and `apple_health_daily`, and `body.vo2_max` populates from the JSON metrics. `tsc` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)